### PR TITLE
Add a Contributing file

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,16 +1,15 @@
 # Contributing
 
-:tada: First of all, welcome to this repository, and thanks for your interest, wether you want to contribute
+:tada: First of all, welcome to this repository, and thanks for your interest, whether you want to contribute
 or simply are interested in opening an issue.
 
-When contributing to this repository, please first discuss the change you wish to make via issue,
-email, or any other method with the owners of this repository before making a change.
+When contributing to this repository, please first discuss the change you wish to make by creating an issue before making a change.
 
 Please note we have a code of conduct, please follow it in all your interactions with the project.
 
 ## Pull Request Process
 
-1. Before pushing your code, please make sure to have it tested and covered by some unit tests.
+1. Before pushing your code, please make sure to have it covered by some unit tests. Also make sure that the code passes both your tests and the other tests.
 
 2. Use our pull request template to submit any changes to the code, even minor.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ Please note we have a code of conduct, please follow it in all your interactions
 
 3. This project is developed using Python3.6 (currently the last Python version),
    and follow the PEP8 (https://www.python.org/dev/peps/pep-0008/) rules. You should enforce this
-   behaviour and also use Pyflakes to check your code for unused library.
+   behaviour and also use Pyflakes to check your code for unused libraries.
 
 ## Code of Conduct
 
@@ -29,13 +29,12 @@ size, disability, ethnicity, sex characteristics, gender identity and expression
 level of experience, education, socio-economic status, nationality, personal
 appearance, race, religion, or sexual identity and orientation.
 
-As part of the Wellcome trust, we expect you to use this code with respect for people
-involved in the analysis of the references you want to parse.
+We expect you to use this code with respect for people involved in the analysis
+of the references you want to parse.
 
 ### Our Standards
 
-Examples of behavior that contributes to creating a positive environment
-include:
+Examples of behaviours which contribute to creating a positive environment include:
 
 * Using welcoming and inclusive language
 * Being respectful of differing viewpoints and experiences
@@ -78,8 +77,8 @@ further defined and clarified by project maintainers.
 ### Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting the project team at [INSERT EMAIL ADDRESS]. All
-complaints will be reviewed and investigated and will result in a response that
+reported by contacting the project team.
+All complaints will be reviewed and investigated and will result in a response that
 is deemed necessary and appropriate to the circumstances. The project team is
 obligated to maintain confidentiality with regard to the reporter of an incident.
 Further details of specific enforcement policies may be posted separately.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,90 @@
+# Contributing
+
+:tada: First of all, welcome to this repository, and thanks for your interest, wether you want to contribute
+or simply are interested in opening an issue.
+
+When contributing to this repository, please first discuss the change you wish to make via issue,
+email, or any other method with the owners of this repository before making a change.
+
+Please note we have a code of conduct, please follow it in all your interactions with the project.
+
+## Pull Request Process
+
+1. Before pushing your code, please make sure to have it tested and covered by some unit tests.
+
+2. Use our pull request template to submit any changes to the code, even minor.
+
+3. This project is developed using Python3.6 (currently the last Python version),
+   and follow the PEP8 (https://www.python.org/dev/peps/pep-0008/) rules. You should enforce this
+   behaviour and also use Pyflakes to check your code for unused library.
+
+## Code of Conduct
+
+### Values we defend
+
+As part of the Wellcome trust, we expect you to use this code with respect for both people
+and licenses involved in the analysis of the references you want to parse.
+
+### Expected behaviour
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+### Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+### Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+### Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at [INSERT EMAIL ADDRESS]. All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+### Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at [http://contributor-covenant.org/version/1/4][version]
+
+[homepage]: http://contributor-covenant.org
+[version]: http://contributor-covenant.org/version/1/4/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,12 +20,19 @@ Please note we have a code of conduct, please follow it in all your interactions
 
 ## Code of Conduct
 
-### Values we defend
+### Our Pledge
 
-As part of the Wellcome trust, we expect you to use this code with respect for both people
-and licenses involved in the analysis of the references you want to parse.
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, sex characteristics, gender identity and expression,
+level of experience, education, socio-economic status, nationality, personal
+appearance, race, religion, or sexual identity and orientation.
 
-### Expected behaviour
+As part of the Wellcome trust, we expect you to use this code with respect for people
+involved in the analysis of the references you want to parse.
+
+### Our Standards
 
 Examples of behavior that contributes to creating a positive environment
 include:


### PR DESCRIPTION
Add a contribution file to guide future contributors through our values, our workflow and our rules.
At the moment, it is a copy from this file -> https://www.contributor-covenant.org/version/1/4/code-of-conduct
Pretty much everything is in it, but we should make sure everything we want lives in this file.
This file should be discussed to ensure that we all agree with what is in it.