### PR TITLE
Fix the reference parser performances issues

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,7 @@
 # Use a basic Python image
-FROM python:3.6.4
+FROM python:3.6.4-slim-stretch
 
 WORKDIR /reference_parser
-
-
-COPY ./models/ /reference_parser/models
 
 COPY ./utils/__init__.py /reference_parser/utils/__init__.py
 COPY ./utils/file_manager.py /reference_parser/utils/file_manager.py

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,23 @@
+.DEFAULT_GOAL := all
+
+IMAGE := uk.ac.wellcome/reference-parser
+ECR_IMAGE := 160358319781.dkr.ecr.eu-west-1.amazonaws.com/$(IMAGE)
+VERSION := 2018.10.0
+
+.PHONY: image
+image:
+	docker build \
+		-t $(IMAGE):$(VERSION) \
+		-t $(IMAGE):latest \
+		-t $(ECR_IMAGE):$(VERSION) \
+		-t $(ECR_IMAGE):latest \
+		.
+
+.PHONY: push
+push: image
+	$$(aws ecr get-login --no-include-email --region eu-west-1) && \
+	docker push $(ECR_IMAGE):$(VERSION) && \
+	docker push $(ECR_IMAGE):latest
+
+.PHONY: all
+all: image

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 IMAGE := uk.ac.wellcome/reference-parser
 ECR_IMAGE := 160358319781.dkr.ecr.eu-west-1.amazonaws.com/$(IMAGE)
-VERSION := 2018.10.0
+VERSION := 2018.12.0
 
 .PHONY: image
 image:

--- a/main.py
+++ b/main.py
@@ -8,7 +8,8 @@ from argparse import ArgumentParser
 from utils import (FileManager,
                    FuzzyMatcher,
                    process_reference_section,
-                   Predictor)
+                   predict_references,
+                   predict_structure)
 from models import DatabaseEngine
 from settings import settings
 
@@ -19,7 +20,6 @@ def run_predict(scraper_file, references_file,
     logger.setLevel('INFO')
     mode = 'S3' if settings.S3 else 'LOCAL'
     fm = FileManager(mode)
-    predictor = Predictor()
     logger.info("[+] Reading input files for %s", settings.ORGANISATION)
 
     # Loading the scraper results
@@ -52,14 +52,25 @@ def run_predict(scraper_file, references_file,
 
     # Predict the references types (eg title/author...)
     logger.info('[+] Predicting the reference components')
-    reference_components_predictions = predictor.predict_references(
+    # reference_components_predictions = predictor.predict_references(
+    #     mnb,
+    #     vectorizer,
+    #     splited_references
+    # )
+    #
+    # # Predict the reference structure????
+    # predicted_reference_structures = predictor.predict_structure(
+    #     reference_components_predictions,
+    #     settings.PREDICTION_PROBABILITY_THRESHOLD
+    # )
+    reference_components_predictions = predict_references(
         mnb,
         vectorizer,
         splited_references
     )
 
     # Predict the reference structure????
-    predicted_reference_structures = predictor.predict_structure(
+    predicted_reference_structures = predict_structure(
         reference_components_predictions,
         settings.PREDICTION_PROBABILITY_THRESHOLD
     )
@@ -129,5 +140,14 @@ if __name__ == '__main__':
         settings.MODEL_DIR,
         settings.VECTORIZER_FILENAME
     )
-
-    run_predict(scraper_file, references_file, model_file, vectorizer_file)
+    if settings.DEBUG:
+        import cProfile
+        cProfile.run(
+            ''.join([
+                'run_predict(scraper_file, references_file,',
+                'model_file, vectorizer_file)'
+            ]),
+            'stats_dumps'
+        )
+    else:
+        run_predict(scraper_file, references_file, model_file, vectorizer_file)

--- a/main.py
+++ b/main.py
@@ -25,7 +25,11 @@ def run_predict(scraper_file, references_file,
     # Loading the scraper results
     scraper_file_name = os.path.basename(scraper_file)
     scraper_file_dir = os.path.dirname(scraper_file)
-    scraper_file = fm.get_file(scraper_file_name, scraper_file_dir, 'json')
+
+    scraper_file = fm.get_scraping_results(
+        scraper_file_name,
+        scraper_file_dir,
+    )
 
     # Loading the references file
     ref_file_name = os.path.basename(references_file)
@@ -52,17 +56,6 @@ def run_predict(scraper_file, references_file,
 
     # Predict the references types (eg title/author...)
     logger.info('[+] Predicting the reference components')
-    # reference_components_predictions = predictor.predict_references(
-    #     mnb,
-    #     vectorizer,
-    #     splited_references
-    # )
-    #
-    # # Predict the reference structure????
-    # predicted_reference_structures = predictor.predict_structure(
-    #     reference_components_predictions,
-    #     settings.PREDICTION_PROBABILITY_THRESHOLD
-    # )
     reference_components_predictions = predict_references(
         mnb,
         vectorizer,
@@ -74,7 +67,6 @@ def run_predict(scraper_file, references_file,
         reference_components_predictions,
         settings.PREDICTION_PROBABILITY_THRESHOLD
     )
-    predicted_reference_structures['Organisation'] = settings.ORGANISATION
 
     fuzzy_matcher = FuzzyMatcher(
         ref_file,

--- a/models.py
+++ b/models.py
@@ -92,6 +92,8 @@ class DatabaseEngine():
 
         # Go through the list of references by documents, add them to the
         # session and commit it to the DB
+
+        self.logger.info('Inserting %s in the db', len(doc_list))
         for idx, doc in enumerate(doc_list):
             serial_doc = serialise_reference(doc, now)
             new_doc_stm = insert(Document).values(
@@ -107,7 +109,11 @@ class DatabaseEngine():
                 id_organisation=org.id,
             )
             new_doc_stm = new_doc_stm.on_conflict_do_nothing(
-                index_elements=['file_hash', 'title']
+                index_elements=[
+                    'file_hash',
+                    'title',
+                    'author',
+                ]
             )
             self.session.execute(new_doc_stm)
             if idx % (100) == 0:

--- a/models.py
+++ b/models.py
@@ -1,12 +1,12 @@
 import pandas as pd
-
 from utils import serialise_matched_reference, serialise_reference
 from settings import settings
 from datetime import datetime
 from sqlalchemy import Column, ForeignKey, Integer, String, DateTime
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import relationship, sessionmaker
-from sqlalchemy import create_engine
+from sqlalchemy import create_engine, and_
+from sqlalchemy.dialects.postgresql import insert
 
 Base = declarative_base()
 
@@ -62,18 +62,26 @@ class DatabaseEngine():
     def __init__(self):
         self.meta = Base.metadata
         self.session = self._get_session(settings.RDS_URL)
+        self.logger = settings.logger
 
     def save_to_database(self, documents, references):
+        self.logger.info('[+] Starting insertion to the DB')
+
+        # This is the list of references by document
         doc_list = documents.where(
             (pd.notnull(documents)),
             None
         ).to_dict(orient='records')
+
+        # This is the list of matched references
         ref_list = references.where(
             (pd.notnull(references)),
             None
         ).to_dict(orient='records')
+
         now = datetime.now().strftime('%Y-%m-%d %H:%M:%S')
 
+        # Get the organisation. If it doesn't exists, create it
         org = self.session.query(Organisation).filter(
             Organisation.name == settings.ORGANISATION
         ).first()
@@ -81,37 +89,42 @@ class DatabaseEngine():
         if not org:
             org = Organisation(name=settings.ORGANISATION)
             self.session.add(org)
-        for doc in doc_list:
+
+        # Go through the list of references by documents, add them to the
+        # session and commit it to the DB
+        for idx, doc in enumerate(doc_list):
             serial_doc = serialise_reference(doc, now)
-            new_doc = self.session.query(Document).filter(
-                Document.file_hash == serial_doc['file_hash']
-                and Document.authors == serial_doc['author']
-                and Document.title == serial_doc['title']
-            ).first()
-            if not new_doc:
-                new_doc = Document(
-                    author=serial_doc['author'],
-                    issue=serial_doc['issue'],
-                    journal=serial_doc['journal'],
-                    volume=serial_doc['volume'],
-                    pub_year=serial_doc['pub_year'],
-                    pagination=serial_doc['pagination'],
-                    title=serial_doc['title'],
-                    file_hash=serial_doc['file_hash'],
-                    datetime_creation=serial_doc['datetime_creation'],
-                    organisation=org,
-                )
-                self.session.add(new_doc)
+            new_doc_stm = insert(Document).values(
+                author=serial_doc['author'],
+                issue=serial_doc['issue'],
+                journal=serial_doc['journal'],
+                volume=serial_doc['volume'],
+                pub_year=serial_doc['pub_year'],
+                pagination=serial_doc['pagination'],
+                title=serial_doc['title'],
+                file_hash=serial_doc['file_hash'],
+                datetime_creation=serial_doc['datetime_creation'],
+                id_organisation=org.id,
+            )
+            new_doc_stm = new_doc_stm.on_conflict_do_nothing(
+                index_elements=['file_hash', 'title']
+            )
+            self.session.execute(new_doc_stm)
+            if idx % (100) == 0:
+                self.session.flush()
         self.session.commit()
-        for ref in ref_list:
+
+        # Go through the list of matched references, add them to the
+        # session and commit it to the DB
+        for idx, ref in enumerate(ref_list):
             serial_ref = serialise_matched_reference(ref, now)
             document = self.session.query(Document).filter(
                 Document.file_hash == serial_ref['document_hash']
             ).first()
-            new_ref = self.session.query(Reference).filter(
-                Reference.publication_id == serial_ref['publication_id']
-                and Reference.id_document == document.id
-            ).first()
+            new_ref = self.session.query(Reference).filter(and_(
+                Reference.publication_id == serial_ref['publication_id'],
+                Reference.publication_id == serial_ref['document_hash']
+            )).first()
             if not new_ref:
                 new_ref = Reference(
                     document=document,

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,4 +14,3 @@ six==1.11.0
 sklearn==0.0
 SQLAlchemy==1.2.12
 urllib3==1.23
-jsonlines==1.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,9 +8,10 @@ psycopg2-binary==2.7.5
 python-dateutil==2.7.3
 pytz==2018.5
 s3transfer==0.1.13
-scikit-learn==0.20.0
+scikit-learn==0.19.2
 scipy==1.1.0
 six==1.11.0
 sklearn==0.0
 SQLAlchemy==1.2.12
 urllib3==1.23
+jsonlines==1.2.0

--- a/settings.py
+++ b/settings.py
@@ -18,12 +18,12 @@ class BaseSettings:
     BUCKET = "datalabs-data"
 
     SCRAPER_RESULTS_DIR = "scraper-results/{}".format(ORGANISATION)
-    SCRAPER_RESULTS_FILENAME = 'nice.json'
+    SCRAPER_RESULTS_FILENAME = ''
 
     REFERENCES_DIR = "wellcome_publications"
     REFERENCES_FILENAME = 'uber_api_publications.csv'
 
-    LOCAL_OUTPUT_DIR  = 'local_output'
+    LOCAL_OUTPUT_DIR = 'local_output'
     PREF_REFS_FILENAME = 'predicted_reference_structures.csv'
     MATCHES_FILENAME = 'all_match_data.csv'
 

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -2,7 +2,7 @@ from .separate import (process_reference_section,
                        summarise_predicted_references,
                        split_sections,
                        split_reference)
-from .predict import Predictor
+from .predict import predict_references, predict_structure
 from .fuzzymatch import FuzzyMatcher
 from .file_manager import FileManager
 from .serialiser import serialise_matched_reference, serialise_reference
@@ -10,11 +10,12 @@ from .serialiser import serialise_matched_reference, serialise_reference
 __all__ = [
     process_reference_section,
     summarise_predicted_references,
-    Predictor,
     FuzzyMatcher,
     FileManager,
     serialise_matched_reference,
     serialise_reference,
     split_sections,
-    split_reference
+    split_reference,
+    predict_references,
+    predict_structure
 ]

--- a/utils/file_manager.py
+++ b/utils/file_manager.py
@@ -1,8 +1,9 @@
 import pandas as pd
 import os
 import pickle
+import tempfile
+import jsonlines
 from .s3 import S3
-from io import StringIO
 from settings import settings
 
 
@@ -20,21 +21,52 @@ class FileManager():
             'pickle': self.load_pickle_file,
         }
 
+    def get_scraping_results(self, file_name, file_prefix):
+        if self.mode == 'S3':
+            with tempfile.TemporaryFile() as tf:
+                # If we don't have the filename, take the last file
+                if not file_name:
+                    file_path = self.s3._get_last_modified_file_key(
+                        file_prefix
+                    )
+                else:
+                    file_path = os.path.join(file_prefix, file_name)
+                self.s3.get(file_path, tf)
+                tf.seek(0)
+                self.logger.info('Using %s file from S3', file_path)
+                columns_to_keep = [
+                    "title",
+                    "hash",
+                    "sections",
+                    "uri"
+                ]
+                json_file = []
+                for obj in jsonlines.Reader(tf):
+                    new_row = {}
+                    for column in columns_to_keep:
+                        new_row[column] = obj[column]
+                    json_file.append(new_row)
+            return pd.DataFrame(json_file)
+
+        return self._get_from_local(file_prefix, file_name, 'json')
+
     def get_file(self, file_name, file_prefix, file_type):
         if self.mode == 'S3':
-            return self._get_from_s3(file_prefix, file_name, file_type)
+            with tempfile.TemporaryFile() as tf:
+                return self._get_from_s3(file_prefix, file_name, file_type, tf)
 
         return self._get_from_local(file_prefix, file_name, file_type)
 
-    def _get_from_s3(self, file_prefix, file_name, file_type):
+    def _get_from_s3(self, file_prefix, file_name, file_type, tf):
         # If we don't have the filename, take the last file
         if not file_name:
             file_path = self.s3._get_last_modified_file_key(file_prefix)
         else:
             file_path = os.path.join(file_prefix, file_name)
-        file_content = self.s3.get(file_path)
+        self.s3.get(file_path, tf)
+        tf.seek(0)
         self.logger.info('Using %s file from S3', file_path)
-        return self.loaders[file_type](file_content)
+        return self.loaders[file_type](tf)
 
     def _get_from_local(self, file_prefix, file_name, file_type):
         file_path = os.path.join(file_prefix, file_name)
@@ -45,18 +77,18 @@ class FileManager():
 
     def load_csv_file(self, file_content):
         """Takes the path and name of a csv file and returns its content."""
-        csv_file = StringIO(file_content.decode('utf-8'))
-        raw_text_data = pd.read_csv(csv_file)
+        # csv_file = StringIO(file_content.decode('utf-8'))
+        raw_text_data = pd.read_csv(file_content)
         return raw_text_data
 
-    def load_json_file(self, file_content):
+    def load_json_file(self, temp_file):
         """Takes the path and name of a json file and returns its content."""
-        raw_text_data = pd.read_json(file_content, lines=True)
+        raw_text_data = pd.read_json(temp_file, lines=True)
         return raw_text_data
 
     def load_pickle_file(self, file_content):
         """Load a pickle file from a given path and file name and returns the
         unpickled file.
         """
-        unpickled_file = pickle.loads(file_content)
+        unpickled_file = pickle.loads(file_content.read())
         return unpickled_file

--- a/utils/file_manager.py
+++ b/utils/file_manager.py
@@ -83,10 +83,11 @@ class FileManager():
 
     def _get_from_local(self, file_prefix, file_name, file_type):
         file_path = os.path.join(file_prefix, file_name)
-        file_content = open(file_path, 'rb')
+        with open(file_path, 'rb') as file_content:
+            self.logger.info('Using %s file from local storage', file_path)
+            dataframe = self.loaders[file_type](file_content)
 
-        self.logger.info('Using %s file from local storage', file_path)
-        return self.loaders[file_type](file_content)
+        return dataframe
 
     def load_csv_file(self, file_content):
         """Takes the path and name of a csv file and returns its content."""

--- a/utils/fuzzymatch.py
+++ b/utils/fuzzymatch.py
@@ -1,11 +1,13 @@
 import numpy as np
 import pandas as pd
+from settings import settings
 from sklearn.feature_extraction.text import TfidfVectorizer
 from sklearn.metrics.pairwise import cosine_similarity
 
 
 class FuzzyMatcher:
     def __init__(self, real_publications, titles):
+        self.logger = settings.logger
         self.vectorizer = TfidfVectorizer(lowercase=True, ngram_range=(1, 1))
         self.tfidf_matrix = self.vectorizer.fit_transform(
             real_publications['title']
@@ -50,10 +52,9 @@ class FuzzyMatcher:
         return match_data
 
     def fuzzy_match_blocks(self, blocksize, predicted_publications, threshold):
-        print(
-            "Fuzzy matching for " + str(
-                len(predicted_publications)
-            ) + " predicted publications ..."
+        self.logger.info(
+            "Fuzzy matching for %s predicted publications ...",
+            len(predicted_publications)
         )
 
         counter = 0
@@ -84,5 +85,5 @@ class FuzzyMatcher:
                      'WT_Ref_Title', 'WT_Ref_Id', 'Cosine_Similarity']
         )
 
-        print(all_match_data.head())
+        self.logger.info(all_match_data.head())
         return all_match_data

--- a/utils/predict.py
+++ b/utils/predict.py
@@ -1,249 +1,285 @@
 import pandas as pd
+from functools import partial
 from settings import settings
+from multiprocessing import Pool
 
 
-class Predictor:
+logger = settings.logger
 
-    def __init__(self):
-        self.logger = settings.logger
 
-    def decide_components(self, single_reference):
-        """With the predicted components of one reference, decide which of
-        these should be used for each component i.e. if there are multiple
-        authors predicted and they arent next to each other, then decide which
-        one to use.
-        """
+def decide_components(single_reference):
+    """With the predicted components of one reference, decide which of
+    these should be used for each component i.e. if there are multiple
+    authors predicted and they arent next to each other, then decide which
+    one to use.
+    """
 
-        # Add a block number, this groups neighbouring predictions of
-        # the same type together.
-        block_number = pd.DataFrame({
-            'Block': (
-                single_reference[
-                    "Predicted Category"
-                ].shift(1) != single_reference[
-                    "Predicted Category"
-                ]).astype(int).cumsum()
-        })
-        single_reference = pd.concat([single_reference, block_number], axis=1)
+    # Add a block number, this groups neighbouring predictions of
+    # the same type together.
+    block_number = pd.DataFrame({
+        'Block': (
+            single_reference[
+                "Predicted Category"
+            ].shift(1) != single_reference[
+                "Predicted Category"
+            ]).astype(int).cumsum()
+    })
+    single_reference = pd.concat([single_reference, block_number], axis=1)
 
-        single_reference_components = {}
+    single_reference_components = {}
 
-        for classes in set(single_reference["Predicted Category"]):
+    for classes in set(single_reference["Predicted Category"]):
 
-            # Are there any sentences of this type (i.e. Authors, Title)?
-            classornot = sum(single_reference['Predicted Category'] == classes)
+        # Are there any sentences of this type (i.e. Authors, Title)?
+        classornot = sum(single_reference['Predicted Category'] == classes)
 
-            if classornot != 0:
+        if classornot != 0:
 
-                # Find how many blocks there are of this class type
-                number_blocks = len(
-                    single_reference['Block'][single_reference[
-                        'Predicted Category'
-                    ] == classes].unique()
-                )
-
-                if number_blocks == 1:
-                    # Just record this block separated by commas
-                    single_reference_components.update({
-                        classes: ", ".join(
-                            single_reference[
-                                'Reference component'
-                            ][single_reference[
-                                'Predicted Category'
-                            ] == classes]
-                        )
-                    })
-                else:
-                    # Pick the block containing the highest probability
-                    # argmax takes the first argument anyway (so if there are 2
-                    # of the same probabilities it takes the first one)
-                    # could decide to do this randomly with argmax.choice()
-                    # (random choice)
-
-                    highest_probability_index = single_reference[
-                        single_reference['Predicted Category'] == classes
-                    ]['Prediction Probability'].idxmax()
-
-                    highest_probability_block = single_reference[
-                        'Block'
-                    ][highest_probability_index]
-
-                    # Use everything in this block, separated by comma
-                    single_reference_components.update({
-                        classes: ", ".join(
-                            single_reference[
-                                "Reference component"
-                            ][single_reference[
-                                'Block'
-                            ] == highest_probability_block]
-                        )
-                    })
-            else:
-                # There are none of this classification, append with blank
-                single_reference_components.update({classes: ""})
-
-        return single_reference_components
-
-    def single_reference_structure(self, components_single_reference,
-                                   prediction_probability_threshold):
-        """Predict the structure for a single reference given all
-        the components predicted for it.
-        """
-        # Delete all the rows which have a probability <0.75
-        components_single_reference = components_single_reference[
-            components_single_reference[
-                'Prediction Probability'
-            ].astype(float) > prediction_probability_threshold
-        ]
-
-        # Decide the best options for each reference component, resulting
-        # in one structured reference
-        single_reference = self.decide_components(components_single_reference)
-        if single_reference:
-            single_reference = pd.DataFrame(
-                self.decide_components(components_single_reference),
-                index=[0]
+            # Find how many blocks there are of this class type
+            number_blocks = len(
+                single_reference['Block'][single_reference[
+                    'Predicted Category'
+                ] == classes].unique()
             )
 
-        return single_reference
+            if number_blocks == 1:
+                # Just record this block separated by commas
+                single_reference_components.update({
+                    classes: ", ".join(
+                        single_reference[
+                            'Reference component'
+                        ][single_reference[
+                            'Predicted Category'
+                        ] == classes]
+                    )
+                })
+            else:
+                # Pick the block containing the highest probability
+                # argmax takes the first argument anyway (so if there are 2
+                # of the same probabilities it takes the first one)
+                # could decide to do this randomly with argmax.choice()
+                # (random choice)
 
-    def predict_structure(self, reference_components_predictions,
-                          prediction_probability_threshold):
-        """Predict the structured references for all the references. Go through
-        each reference for each document in turn.
-        """
+                highest_probability_index = single_reference[
+                    single_reference['Predicted Category'] == classes
+                ]['Prediction Probability'].idxmax()
 
-        all_structured_references = {}
-        document_ids = set(reference_components_predictions['Document id'])
+                highest_probability_block = single_reference[
+                    'Block'
+                ][highest_probability_index]
 
-        self.logger.info(document_ids)
+                # Use everything in this block, separated by comma
+                single_reference_components.update({
+                    classes: ", ".join(
+                        single_reference[
+                            "Reference component"
+                        ][single_reference[
+                            'Block'
+                        ] == highest_probability_block]
+                    )
+                })
+        else:
+            # There are none of this classification, append with blank
+            single_reference_components.update({classes: ""})
 
-        print(
-            "Predicting structure of references from ",
-            str(len(document_ids)),
-            " documents ... "
+    return single_reference_components
+
+
+def single_reference_structure(components_single_reference,
+                               prediction_probability_threshold):
+    """Predict the structure for a single reference given all
+    the components predicted for it.
+    """
+    # Delete all the rows which have a probability <0.75
+    components_single_reference = components_single_reference[
+        components_single_reference[
+            'Prediction Probability'
+        ].astype(float) > prediction_probability_threshold
+    ]
+
+    # Decide the best options for each reference component, resulting
+    # in one structured reference
+    single_reference = pd.DataFrame(
+        decide_components(components_single_reference),
+        index=[0]
+    )
+
+    return single_reference
+
+
+def _get_structure(reference_id, document):
+    # The components and predictions for one document one reference
+
+    components_single_reference = document.loc[
+        document['Reference id'] == reference_id
+    ].reset_index()
+
+    # Structure:
+    single_reference = single_reference_structure(
+        components_single_reference,
+        settings.PREDICTION_PROBABILITY_THRESHOLD
+    )
+
+    if len(single_reference) != 0:
+
+        # Only if there were some enteries for this reference with
+        # high prediction probabilies
+        single_reference[
+            "Document id"
+        ] = components_single_reference['Document id'][0]
+
+        single_reference[
+            "Reference id"
+        ] = components_single_reference['Reference id'][0]
+
+        single_reference[
+            "Document uri"
+        ] = components_single_reference['Document uri'][0]
+
+    return pd.DataFrame.from_dict(single_reference)
+
+
+def predict_structure(reference_components_predictions,
+                      prediction_probability_threshold,
+                      num_workers=None):
+    """Predict the structured references for all the references. Go through
+    each reference for each document in turn.
+    """
+
+    all_structured_references = []
+    document_ids = set(reference_components_predictions['Document id'])
+
+    logger.info(
+        "[+] Predicting structure of references from %s  documents...",
+        str(len(document_ids))
+    )
+    if num_workers == 1:
+        pool_map = map
+    else:
+        pool = Pool(num_workers)
+        pool_map = pool.map
+        logger.info(
+            '[+] Using pooled predictor with %s workers',
+            pool._processes
         )
-        tt = 0
-        for document_id in document_ids:
-            document = reference_components_predictions.loc[
-                reference_components_predictions['Document id'] == document_id
-            ]
-
-            reference_ids = set(document['Reference id'])
-            for reference_id in reference_ids:
-                # The components and predictions for one document one reference
-                components_single_reference = document.loc[
-                    document['Reference id'] == reference_id
-                ].reset_index()
-
-                # Structure:
-                single_reference = self.single_reference_structure(
-                    components_single_reference,
-                    prediction_probability_threshold
-                )
-
-                if len(single_reference) != 0:
-
-                    # Only if there were some enteries for this reference with
-                    # high prediction probabilies
-                    single_reference[
-                        "Document id"
-                    ] = components_single_reference['Document id'][0]
-
-                    single_reference[
-                        "Reference id"
-                    ] = components_single_reference['Reference id'][0]
-
-                    single_reference[
-                        "Document uri"
-                    ] = components_single_reference['Document uri'][0]
-
-                    # Merge with the rest:
-                    if tt == 0:
-                        all_structured_references = single_reference
-                    else:
-                        all_structured_references = pd.concat(
-                            [all_structured_references, single_reference],
-                            axis=0,
-                            ignore_index=True,
-                            sort=False
-                        )
-                    tt = tt + 1
-
-        print("Reference structure predicted")
-        return all_structured_references
-
-    def predict_reference_comp(self, mnb, vectorizer, word_list):
-        # To test what individual things predict,
-        # it can deal with a list input or not
-        # The maximum probability found is the probability
-        # of the predicted classification
-
-        vec_list = vectorizer.transform(word_list).toarray()
-        predict_component = mnb.predict(vec_list)
-        predict_component_probas = mnb.predict_proba(vec_list)
-        predict_component_proba = [
-            single_predict.max() for single_predict in predict_component_probas
+    for document_id in document_ids:
+        document = reference_components_predictions.loc[
+            reference_components_predictions['Document id'] == document_id
         ]
 
-        return predict_component, predict_component_proba
+        reference_ids = set(document['Reference id'])
 
-    def predict_references(self, mnb, vectorizer, reference_components):
-
-        print(
-            "Predicting the categories of ",
-            str(len(reference_components)),
-            " reference components ... "
+        # doc_references = map(
+        #     lambda x: _get_structure(x, document),
+        #     reference_ids
+        # )
+        doc_references = pool_map(
+            partial(_get_structure,
+                    document=document),
+            reference_ids
+        )
+        all_structured_references.extend(
+            doc_references
         )
 
-        predict_all = []
+    all_structured_references = pd.concat(
+        all_structured_references,
+        axis=0,
+        ignore_index=True,
+        sort=False
+    )
 
-        # The model cant deal with predicting so many all at once,
-        # so predict in a loop
-        for component in reference_components['Reference component']:
+    logger.info("[+] Reference structure predicted")
+    return all_structured_references
 
-            # The training data was all from 2017, so the categorisation for
-            # year will never work (unless it's 2017)
-            # So set to pubyear uf any 4 digit numbers where first
-            # 2 digits are 18, 19 or 20 sentences as years.
-            valid_years_range = range(1800, 2020)
-            if (
-               (component.isdecimal()
-                and int(component) in valid_years_range)
-               or (
-                   len(component) == 6
-                   and component[1:5].isdecimal()
-                   and int(component[1:5]) in valid_years_range)
-               ):
-                predict_all.append({
-                    'Predicted Category': 'PubYear',
-                    'Prediction Probability': 1
-                })
 
-            else:
-                # If it's not a year, then classify with the model
-                (predict_comp,
-                 predict_component_proba) = self.predict_reference_comp(
-                    mnb,
-                    vectorizer,
-                    [component]
-                )
-                predict_all.append({
-                    'Predicted Category': predict_comp[0],
-                    'Prediction Probability': predict_component_proba[0]
-                    })
+def predict_reference_comp(mnb, vectorizer, word_list):
+    # To test what individual things predict,
+    # it can deal with a list input or not
+    # The maximum probability found is the probability
+    # of the predicted classification
 
-        predict_all = pd.DataFrame.from_dict(predict_all)
+    vec_list = vectorizer.transform(word_list).toarray()
+    predict_component = mnb.predict(vec_list)
+    predict_component_probas = mnb.predict_proba(vec_list)
+    predict_component_proba = [
+        single_predict.max() for single_predict in predict_component_probas
+    ]
 
-        reference_components_predictions = reference_components.reset_index()
+    return predict_component, predict_component_proba
 
-        reference_components_predictions[
-            "Predicted Category"
-        ] = predict_all['Predicted Category']
 
-        reference_components_predictions[
-            "Prediction Probability"
-        ] = predict_all['Prediction Probability']
+def _get_year_or_component(component, mnb, vectorizer):
+    valid_years_range = range(1800, 2020)
+    if (
+       (component.isdecimal()
+        and int(component) in valid_years_range)
+       or (
+           len(component) == 6
+           and component[1:5].isdecimal()
+           and int(component[1:5]) in valid_years_range)
+       ):
+        return {
+            'Predicted Category': 'PubYear',
+            'Prediction Probability': 1
+        }
 
-        print("Predictions complete")
-        return reference_components_predictions
+    else:
+        # If it's not a year, then classify with the model
+        (predict_comp,
+         predict_component_proba) = predict_reference_comp(
+            mnb,
+            vectorizer,
+            [component]
+        )
+        return {
+            'Predicted Category': predict_comp[0],
+            'Prediction Probability': predict_component_proba[0]
+            }
+
+
+def predict_references(mnb,
+                       vectorizer,
+                       reference_components,
+                       num_workers=None):
+
+    logger.info(
+        "[+] Predicting the categories of %s  reference components ...",
+        str(len(reference_components))
+    )
+
+    predict_all = []
+
+    # The model cant deal with predicting so many all at once,
+    # so predict in a loop
+    if num_workers == 1:
+        pool_map = map
+    else:
+        pool = Pool(num_workers)
+        pool_map = pool.map
+        logger.info(
+            '[+] Using pooled predictor with %s workers',
+            pool._processes
+        )
+
+    predict_all = list(pool_map(
+        partial(_get_year_or_component,
+                mnb=mnb,
+                vectorizer=vectorizer),
+        reference_components.get('Reference component', [])
+    ))
+
+    predict_all = pd.DataFrame.from_dict(predict_all)
+
+    reference_components_predictions = reference_components.reset_index()
+
+    reference_components_predictions[
+        "Predicted Category"
+    ] = predict_all['Predicted Category']
+
+    reference_components_predictions[
+        "Prediction Probability"
+    ] = predict_all['Prediction Probability']
+
+    logger.info("Predictions complete")
+    return reference_components_predictions

--- a/utils/s3.py
+++ b/utils/s3.py
@@ -1,9 +1,11 @@
 import boto3
+from settings import settings
 from botocore.exceptions import ClientError
 
 
 class S3():
     def __init__(self, bucket_name):
+        self.logger = settings.logger
         self.s3 = boto3.resource('s3')
         self.client = boto3.client('s3')
         self.bucket_name = bucket_name
@@ -33,9 +35,10 @@ class S3():
             return last_added
 
     def get(self, key):
+        self.logger.info('[+] Trying to fetch %s from s3', key)
         last_file = self.client.get_object(
             Bucket=self.bucket_name,
-            Key=key
+            Key=key,
         )
         last_content = last_file.get('Body').read()
 

--- a/utils/s3.py
+++ b/utils/s3.py
@@ -17,11 +17,11 @@ class S3():
                 Prefix=prefix
             ).get('Contents', [])
         except ClientError:
-            print('Could not connect to s3 bucket.')
+            self.logger.info('Could not connect to s3 bucket.')
             return ''
 
         if not objs:
-            print('Could not get last result file.')
+            self.logger.info('Could not get last result file.')
             last_added = []
             return last_added
         else:
@@ -34,12 +34,7 @@ class S3():
             ][0]
             return last_added
 
-    def get(self, key):
-        self.logger.info('[+] Trying to fetch %s from s3', key)
-        last_file = self.client.get_object(
-            Bucket=self.bucket_name,
-            Key=key,
-        )
-        last_content = last_file.get('Body').read()
-
-        return last_content
+    def get(self, key, temp_file):
+        self.logger.info('[+] Fetching s3://%s/%s', self.bucket_name, key)
+        object = self.s3.Object(self.bucket_name, key)
+        object.download_fileobj(temp_file)

--- a/utils/separate.py
+++ b/utils/separate.py
@@ -4,6 +4,9 @@ import re
 
 import numpy as np
 import pandas as pd
+from settings import settings
+
+logger = settings.logger
 
 
 def split_reference(reference):
@@ -68,7 +71,10 @@ def process_reference_section(raw_text_data, regex):
     Nomenclature:
     Document > Reference > Reference components
     """
-    print("Processing unstructured references into reference components ... ")
+
+    logger.info(
+        "Processing unstructured references into reference components ... "
+    )
 
     assert 'sections' in raw_text_data, "raw_text_data.sections not defined"
 
@@ -102,7 +108,7 @@ def process_reference_section(raw_text_data, regex):
 
     reference_components = pd.DataFrame(raw_reference_components)
 
-    print("Reference components found")
+    logger.info("Reference components found")
 
     return reference_components
 
@@ -110,7 +116,7 @@ def process_reference_section(raw_text_data, regex):
 def summarise_predicted_references(reference_components, raw_text_data):
     """Get the number of references and information for each document."""
 
-    print("Number of references for each document being found ... ")
+    logger.info("Number of references for each document being found ... ")
     assert 'sections' in raw_text_data, "raw_text_data.sections not defined"
 
     #####
@@ -149,10 +155,10 @@ def summarise_predicted_references(reference_components, raw_text_data):
 
     count_ref = len([i for i in raw_text_data["sections"] if i])
 
-    print("Number of JSON with reference section is ", str(count_ref))
-    print("Number of JSON is ", str(len(raw_text_data)))
-    print(
-        "Average number of references predicted ",
+    logger.info("Number of JSON with reference section is %s", str(count_ref))
+    logger.info("Number of JSON is %s", str(len(raw_text_data)))
+    logger.info(
+        "Average number of references predicted %s",
         str(round(np.mean(
             predicted_number_refs['Predicted number of references']
         )))
@@ -162,10 +168,10 @@ def summarise_predicted_references(reference_components, raw_text_data):
 
 
 def save_reference_components(reference_components):
-    print("Saving reference components ... ")
+    logger.info("Saving reference components ... ")
     reference_components.to_csv('reference_components.csv', index=False)
 
 
 def save_predicted_number_refs(predicted_number_refs):
-    print("Saving predicted number of references ... ")
+    logger.info("Saving predicted number of references ... ")
     predicted_number_refs.to_csv('predicted_number_refs.csv', index=False)

--- a/utils/serialiser.py
+++ b/utils/serialiser.py
@@ -11,10 +11,10 @@ def serialise_matched_reference(data, current_timestamp):
 
 def serialise_reference(data, current_timestamp):
     """Serialise the data parsed by the model."""
-    if data.get('Title'):
+    if data.get('Title', '') and len(data.get('Title', '')) > 1024:
         title = data['Title'][:1024]
     else:
-        title = None
+        title = data.get('Title', None)
 
     for key, value in data.items():
         if value and key != 'Title' and type(value) == str:


### PR DESCRIPTION
# Description

[This PR looks big, but it's mostly due to switching back the Predictor class to a module with functions]

The reference parser had big ussues dealing with big files (e.g. the who scraping results, about 1.5Go). This PR aims to fix these issues by:

- Using multiprocessing to predict the references components and references
- Using a tempfile to read the scraping result file from S3
- Parsing the json file prior to its treatment in memory to remove big and useless chunks from it (e.g. the PDF full text)
- Indexing the database (manually done - see issue on datalabs infra for more details)
- Using an UPSERT statement instead of a SELECT and an INSERT (twice less requests to the database)

## Type of change

Please delete options that are not relevant.

- [x] ⚡️ Performance update


# How Has This Been Tested?

This has been tested by running pultiple tests both locally and in the cloud in order to benchmark performances before and after these changes.

# Checklist:

- [x] My code follows the style guidelines of this project (pep8 AND pyflakes)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] If needed, I changed related parts of the documentation
- [x] I included tests in my PR - Irrelevant
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] If my PR aims to fix an issue, I referenced it using `#(issue)` - Irrelevant
