### PR TITLE
Add Click to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,7 @@
 boto3==1.9.27
 botocore==1.12.27
+certifi==2018.11.29
+Click==7.0
 docutils==0.14
 jmespath==0.9.3
 numpy==1.15.2
@@ -10,8 +12,8 @@ pytz==2018.5
 s3transfer==0.1.13
 scikit-learn==0.19.2
 scipy==1.1.0
+sentry-sdk==0.6.2
 six==1.11.0
 sklearn==0.0
 SQLAlchemy==1.2.12
 urllib3==1.23
-sentry-sdk==0.6.2


### PR DESCRIPTION
# Description

Add Click to requirements after decision to ditch Pipfile as Click is needed from `manage.py` to run the parser.

To update the requirements I did
```
pip install Click
pip freeze > requirements.txt
```
all in a separate virtualenv. This led to some additional packages added to the requirements. Let me know If you want me to follow a different process in the future.