### PR TITLE
Allowing the S3/local distinction to be specified in arguments of main

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,9 +45,21 @@ Once you're happy with your configuration, just run `python main.py`
 
 ### Method 3.
 
-Edit the `main.py` arguments in `run_parser.sh` to include the names of the input and output file locations desired. If the `scraper_file`, `references_file`, `model_file`, and `vectorizer_file` arguments are to S3 locations then make sure these start with `s3://`, otherwise file names are assumed to be locally stored. If the `output_url` argument is to a local location, then make sure it begins with `file://`, otherwise it is assumed to be from a database.
+Make an output folder `output_folder_name` and run `main.py` with arguments of your file locations, e.g. in the terminal run:
 
-Then run in the terminal `./run_parser.sh`. 
+```
+mkdir -p /tmp/parser-output/output_folder_name
+
+python3 $DIR/main.py \
+	--scraper-file "s3://datalabs-data/scraper-results/msf/20190117.json" \
+	--references-file "match-references/MRC_Publications_Nov2018_JGHT_JHSRI.csv" \
+	--model-file "s3://datalabs-data/reference_parser_models/RefSorter_classifier.pkl" \
+	--vectorizer-file "s3://datalabs-data/reference_parser_models/RefSorter_vectorizer.pkl" \
+	--output-url "file:///tmp/parser-output/output_folder_name"
+```
+
+If the `scraper_file`, `references_file`, `model_file`, and `vectorizer_file` arguments are to S3 locations then make sure these start with `s3://`, otherwise file names are assumed to be locally stored. If the `output_url` argument is to a local location, then make sure it begins with `file://`, otherwise it is assumed to be from a database.
+
 
 ## Contributing
 See the [Contributing guidelines](./CONTRIBUTING.md)

--- a/README.md
+++ b/README.md
@@ -43,5 +43,11 @@ This repository includes a `settings.py` file, where you can manually configure 
 
 Once you're happy with your configuration, just run `python main.py`
 
+### Method 3.
+
+Edit the `main.py` arguments in `run_parser.sh` to include the names of the input and output file locations desired. If the `scraper_file`, `references_file`, `model_file`, and `vectorizer_file` arguments are to S3 locations then make sure these start with `s3://`, otherwise file names are assumed to be locally stored. If the `output_url` argument is to a local location, then make sure it begins with `file://`, otherwise it is assumed to be from a database.
+
+Then run in the terminal `./run_parser.sh`. 
+
 ## Contributing
 See the [Contributing guidelines](./CONTRIBUTING.md)

--- a/main.py
+++ b/main.py
@@ -2,10 +2,12 @@
 and a list of publication.
 """
 
+from argparse import ArgumentParser
+from urllib.parse import urlparse
 import time
 import os
-from argparse import ArgumentParser
 import sentry_sdk
+
 from utils import (FileManager,
                    FuzzyMatcher,
                    process_reference_section,
@@ -15,37 +17,78 @@ from models import DatabaseEngine
 from settings import settings
 
 
+def check_references_file(ref_file, references_file):
+    assert 'title' in ref_file, "ref_file.title not defined in " + references_file + " consider renaming current title column name 'title'"
+    assert 'uber_id' in ref_file, "ref_file.uber_id not defined in " + references_file + " consider renaming current uber id column name to 'uber_id'"
+
 def run_predict(scraper_file, references_file,
-                model_file, vectorizer_file):
+                model_file, vectorizer_file,
+                output_url):
     logger = settings.logger
 
     logger.setLevel('INFO')
-    mode = 'S3' if settings.S3 else 'LOCAL'
-    fm = FileManager(mode)
     logger.info("[+] Reading input files for %s", settings.ORGANISATION)
 
     # Loading the scraper results
-    scraper_file_name = os.path.basename(scraper_file)
-    scraper_file_dir = os.path.dirname(scraper_file)
-
+    if scraper_file.startswith('s3://'):
+        u = urlparse(scraper_file)
+        fm = FileManager('S3', bucket=u.netloc)
+        scraper_file_name = os.path.basename(u.path)
+        scraper_file_dir = os.path.dirname(u.path)[1:]  # strip first /
+    else:
+        fm = FileManager('LOCAL')
+        scraper_file_name = os.path.basename(scraper_file)
+        scraper_file_dir = os.path.dirname(scraper_file)
     scraper_file = fm.get_scraping_results(
         scraper_file_name,
         scraper_file_dir,
     )
 
     # Loading the references file
-    ref_file_name = os.path.basename(references_file)
-    ref_file_dir = os.path.dirname(references_file)
-    ref_file = fm.get_file(ref_file_name, ref_file_dir, 'csv')
+    if references_file.startswith('s3://'):
+        u = urlparse(references_file)
+        fm = FileManager('S3', bucket=u.netloc)
+        ref_file_name = os.path.basename(u.path)
+        ref_file_dir = os.path.dirname(u.path)[1:]  # strip /
+    else:
+        fm = FileManager('LOCAL')
+        ref_file_name = os.path.basename(references_file)
+        ref_file_dir = os.path.dirname(references_file)
+    ref_file = fm.get_file(
+        ref_file_name,
+        ref_file_dir,
+        'csv')
+    check_references_file(ref_file, references_file)
 
     # Loading the model and the vectoriser
-    model_file_name = os.path.basename(model_file)
-    model_file_dir = os.path.dirname(model_file)
-    mnb = fm.get_file(model_file_name, model_file_dir, 'pickle')
+    if model_file.startswith('s3://'):
+        u = urlparse(model_file)
+        fm = FileManager('S3', bucket=u.netloc)
+        model_file_name = os.path.basename(u.path)
+        model_file_dir = os.path.dirname(u.path)[1:]  # strip /
+    else:
+        fm = FileManager('LOCAL')
+        model_file_name = os.path.basename(model_file)
+        model_file_dir = os.path.dirname(model_file)    
+    mnb = fm.get_file(
+        model_file_name,
+        model_file_dir,
+        'pickle')
 
-    vect_file_name = os.path.basename(vectorizer_file)
-    vect_file_dir = os.path.dirname(vectorizer_file)
-    vectorizer = fm.get_file(vect_file_name, vect_file_dir, 'pickle')
+    if vectorizer_file.startswith('s3://'):
+        u = urlparse(vectorizer_file)
+        fm = FileManager('S3', bucket=u.netloc)
+        vect_file_name = os.path.basename(u.path)
+        vect_file_dir = os.path.dirname(u.path)[1:]  # strip /
+    else:
+        fm = FileManager('LOCAL')
+        vect_file_name = os.path.basename(vectorizer_file)
+        vect_file_dir = os.path.dirname(vectorizer_file)
+
+    vectorizer = fm.get_file(
+        vect_file_name,
+        vect_file_dir,
+        'pickle')
 
     # Split the reference sections using regex
     logger.info('[+] Spliting the references')
@@ -80,25 +123,28 @@ def run_predict(scraper_file, references_file,
         settings.FUZZYMATCH_THRESHOLD
     )
 
-    if not settings.DEBUG:
-        database = DatabaseEngine()
-        database.save_to_database(
-            predicted_reference_structures,
-            all_match_data,
-        )
-    else:
+    if output_url.startswith('file://'):
+        # use everything after first two slashes; this handles
+        # absolute and relative urls equally well
+        output_dir = output_url[7:]
         predicted_reference_structures.to_csv(
             os.path.join(
-                settings.LOCAL_OUTPUT_DIR,
+                output_dir,
                 settings.PREF_REFS_FILENAME
                 )
             )
         all_match_data.to_csv(
             os.path.join(
-                settings.LOCAL_OUTPUT_DIR,
+                output_dir,
                 settings.MATCHES_FILENAME
                 )
             )
+    else:
+        database = DatabaseEngine(output_url)
+        database.save_to_database(
+            predicted_reference_structures,
+            all_match_data,
+        )
 
     t1 = time.time()
     total = t1-t0
@@ -113,43 +159,88 @@ def run_predict(scraper_file, references_file,
 if __name__ == '__main__':
     # SENTRY_DSN must be present at import time. If we don't have it then,
     # we won't have it later either.
-    sentry_sdk.init(os.environ['SENTRY_DSN'])
+    try:
+        sentry_sdk.init(os.environ['SENTRY_DSN'])
+    except:
+        pass
 
     try:
         parser = ArgumentParser(description=__doc__.strip())
-        parser.parse_args()
-
-        scraper_file = os.path.join(
-            settings.SCRAPER_RESULTS_DIR,
-            settings.SCRAPER_RESULTS_FILENAME
+        parser.add_argument(
+            '--scraper-file',
+            help='Path or S3 URL to scraper results file'
         )
-
-        references_file = os.path.join(
-            settings.REFERENCES_DIR,
-            settings.REFERENCES_FILENAME
+        parser.add_argument(
+            '--references-file',
+            help='Path or S3 URL to references CSV file to match against'
         )
-
-        model_file = os.path.join(
-            settings.MODEL_DIR,
-            settings.CLASSIFIER_FILENAME
+        parser.add_argument(
+            '--model-file',
+            help='Path or S3 URL to model pickle file'
         )
-
-        vectorizer_file = os.path.join(
-            settings.MODEL_DIR,
-            settings.VECTORIZER_FILENAME
+        parser.add_argument(
+            '--vectorizer-file',
+            help='Path or S3 URL to vectorizer pickle file'
         )
+        parser.add_argument(
+            '--output-url',
+            help='URL (file://!) or DSN for output'
+        )
+        args = parser.parse_args()
+
+        if args.scraper_file is None:
+            scraper_file = os.path.join(
+                settings.SCRAPER_RESULTS_DIR,
+                settings.SCRAPER_RESULTS_FILENAME
+            )
+        else:
+            scraper_file = args.scraper_file
+
+        if args.references_file is None:
+            references_file = os.path.join(
+                settings.REFERENCES_DIR,
+                settings.REFERENCES_FILENAME
+            )
+        else:
+            references_file = args.references_file
+
+        if args.model_file is None:
+            model_file = os.path.join(
+                settings.MODEL_DIR,
+                settings.CLASSIFIER_FILENAME
+            )
+        else:
+            model_file = args.model_file
+
+        if args.vectorizer_file is None:
+            vectorizer_file = os.path.join(
+                settings.MODEL_DIR,
+                settings.VECTORIZER_FILENAME
+            )
+        else:
+            vectorizer_file = args.vectorizer_file
+
+        if args.output_url is None:
+            output_url = settings.OUTPUT_URL
+            #os.path.join(
+            #    settings.REFERENCES_DIR,
+            #    settings.REFERENCES_FILENAME
+            #)
+        else:
+            output_url = args.output_url
+
         if settings.DEBUG:
             import cProfile
             cProfile.run(
                 ''.join([
                     'run_predict(scraper_file, references_file,',
-                    'model_file, vectorizer_file)'
+                    'model_file, vectorizer_file, output_url)'
                 ]),
                 'stats_dumps'
             )
         else:
             run_predict(scraper_file, references_file,
-                        model_file, vectorizer_file)
+                        model_file, vectorizer_file, output_url)
     except Exception as e:
         sentry_sdk.capture_exception(e)
         raise

--- a/main.py
+++ b/main.py
@@ -29,7 +29,7 @@ def check_references_file(ref_file, references_file):
         " consider renaming current uber id column name to 'uber_id'"
     )
 
-def get_file(file_str, file_type, get_scraped = None):
+def get_file(file_str, file_type, get_scraped = False):
     if file_str.startswith('s3://'):
         u = urlparse(file_str)
         fm = FileManager('S3', bucket=u.netloc)
@@ -57,7 +57,7 @@ def run_predict(scraper_file, references_file,
     logger.info("[+] Reading input files for %s", settings.ORGANISATION)
 
     # Loading the scraper results
-    scraper_file = get_file(scraper_file, "", True)
+    scraper_file = get_file(scraper_file, "", get_scraped=True)
 
     # Loading the references file
     ref_file = get_file(references_file, 'csv')

--- a/models.py
+++ b/models.py
@@ -59,9 +59,9 @@ class DatabaseEngine():
         DBSession = sessionmaker(bind=engine)
         return DBSession()
 
-    def __init__(self):
+    def __init__(self, url=settings.RDS_URL):
         self.meta = Base.metadata
-        self.session = self._get_session(settings.RDS_URL)
+        self.session = self._get_session(url)
         self.logger = settings.logger
 
     def save_to_database(self, documents, references):

--- a/settings.py
+++ b/settings.py
@@ -17,17 +17,17 @@ class BaseSettings:
 
     BUCKET = "datalabs-data"
 
-    SCRAPER_RESULTS_DIR = "scraper-results/{}".format(ORGANISATION)
+    SCRAPER_RESULTS_DIR = "s3://{}/scraper-results/{}".format(BUCKET, ORGANISATION)
     SCRAPER_RESULTS_FILENAME = ''
 
-    REFERENCES_DIR = "wellcome_publications"
+    REFERENCES_DIR = "s3://{}/wellcome_publications".format(BUCKET)
     REFERENCES_FILENAME = 'uber_api_publications.csv'
 
     LOCAL_OUTPUT_DIR = 'local_output'
     PREF_REFS_FILENAME = 'predicted_reference_structures.csv'
     MATCHES_FILENAME = 'all_match_data.csv'
 
-    MODEL_DIR = "reference_parser_models"
+    MODEL_DIR = "s3://{}/reference_parser_models".format(BUCKET)
     CLASSIFIER_FILENAME = "RefSorter_classifier.pkl"
     VECTORIZER_FILENAME = "RefSorter_vectorizer.pkl"
 
@@ -51,13 +51,14 @@ class ProdSettings(BaseSettings):
 
     S3 = True
 
-    RDS_URL = "postgresql+psycopg2://{user}:{passw}@{host}:{port}/{db}".format(
+    OUTPUT_URL = "postgresql+psycopg2://{user}:{passw}@{host}:{port}/{db}".format(
           user=RDS_USERNAME,
           passw=RDS_PASSWORD,
           host=RDS_HOST,
           port=RDS_PORT,
           db=RDS_REFERENCES_DATABASE
     )
+    RDS_URL = OUTPUT_URL  # DEPRECATED
 
 
 class LocalSettings(BaseSettings):
@@ -71,13 +72,19 @@ class LocalSettings(BaseSettings):
     RDS_PORT = os.environ.get('RDS_PORT', 5432)
     RDS_REFERENCES_DATABASE = "parser_references"
 
-    RDS_URL = "postgresql+psycopg2://{user}:{passw}@{host}:{port}/{db}".format(
+
+    SCRAPER_RESULTS_DIR = "scraper-results/{}".format(BaseSettings.ORGANISATION)
+    REFERENCES_DIR = "wellcome_publications"
+    MODEL_DIR = "reference_parser_models"
+
+    OUTPUT_URL = "postgresql+psycopg2://{user}:{passw}@{host}:{port}/{db}".format(
           user=RDS_USERNAME,
           passw=RDS_PASSWORD,
           host=RDS_HOST,
           port=RDS_PORT,
           db=RDS_REFERENCES_DATABASE
     )
+    RDS_URL = OUTPUT_URL  # DEPRECATED
 
 
 settings_mode = {

--- a/utils/file_manager.py
+++ b/utils/file_manager.py
@@ -11,12 +11,12 @@ SCRAPING_COLUMNS = ('title', 'hash', 'sections', 'uri')
 
 
 class FileManager():
-    def __init__(self, mode='LOCAL'):
+    def __init__(self, mode='LOCAL', bucket=settings.BUCKET):
         self.mode = mode
         self.logger = settings.logger
         self.logger.setLevel('INFO')
         if self.mode == 'S3':
-            self.s3 = S3(settings.BUCKET)
+            self.s3 = S3(bucket)
 
         self.loaders = {
             'csv': self.load_csv_file,


### PR DESCRIPTION
# Description

This PR adapts mostly `main.py` so that it can be run with new arguments, these are:
- '--scraper-file'
- '--references-file'
- '--model-file'
- '--vectorizer-file'
- '--output-url'

Because S3 files start with 's3://' and the output url will start with 'file://' we can now distingush LOCAL and S3 runs of the code with these arguments rather than previously where we used variables in settings.

This means some parts of `settings.py` have been updated, and further work will also be needed.

I have also added `check_references_file` to `main.py` to make sure the user inputted references have the correct column names, and `get_file` to functionise a repeated process.

A small neatening of `models.py` is included in this PR.

## Type of change

Please delete options that are not relevant.
- [x] :sparkles: New feature

# How Has This Been Tested?

I've run the code successfully with a mixture of S3 and local arguments.

# Checklist:

- [x] My code follows the style guidelines of this project (pep8 AND pyflakes)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] If needed, I changed related parts of the documentation
- [ ] I included tests in my PR
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] If my PR aims to fix an issue, I referenced it using `#(issue)`
